### PR TITLE
Add support for `.svelte` files

### DIFF
--- a/QLPlugin/Info.plist
+++ b/QLPlugin/Info.plist
@@ -134,6 +134,7 @@
 				<string>dyn.ah62d4rv4ge81g3pws3y0g3k</string> <!-- .service (systemd) -->
 				<string>dyn.ah62d4rv4ge81g6dbsm202</string> <!-- .sparql (SPARQL) -->
 				<string>dyn.ah62d4rv4ge81g6pq</string> <!-- .sql -->
+				<string>dyn.ah62d4rv4ge81g7xfrv4gn</string> <!-- .svelte -->
 				<string>dyn.ah62d4rv4ge81k55d</string> <!-- .toc (LaTeX) -->
 				<string>dyn.ah62d4rv4ge81k55rru</string> <!-- .toml -->
 				<string>dyn.ah62d4rv4ge81k652</string> <!-- .tsx -->


### PR DESCRIPTION
Add support for `.svelte` file extension.

Links: https://svelte.dev/ or https://github.com/sveltejs/svelte

---

```
$ mdls -name kMDItemContentType -name kMDItemContentTypeTree App.svelte

kMDItemContentType     = "dyn.ah62d4rv4ge81g7xfrv4gn"
kMDItemContentTypeTree = (
    "public.item",
    "dyn.ah62d4rv4ge81g7xfrv4gn",
    "public.data"
)
```

---

@samuelmeuli Is it possible to test these changes locally? I tried to build it via Xcode, but sadly without any success. 

Thanks in advance!


Cheers
Stefan